### PR TITLE
Fix: Correct syntax errors in various Python files

### DIFF
--- a/client/messages_agent.py
+++ b/client/messages_agent.py
@@ -60,4 +60,3 @@ def format_config_value_missing_info(key_name, section_name, default_value):
 
 def format_config_section_missing_info(section_name):
     return f"Info: Configuration section '[{section_name}]' not found. Using defaults for all its settings."
-```

--- a/server/messages_server.py
+++ b/server/messages_server.py
@@ -99,4 +99,3 @@ DASHBOARD_UNEXPECTED_FETCH_ERROR = "An unexpected error occurred fetching data f
 API_ROLLBACK_ERROR = "Error during rollback attempt: {}" # Generic for API routes
 API_DB_ERROR_GENERAL = "Database error during API request [{}]: {}" # Route info, error
 API_UNEXPECTED_ERROR_GENERAL = "Unexpected error during API request [{}]: {}" # Route info, error
-```

--- a/server/sql_dml.py
+++ b/server/sql_dml.py
@@ -72,4 +72,3 @@ SELECT_LATEST_ACTIVITY_FOR_COMPUTER = """
 # Note: The dashboard alert section will likely involve more specific queries
 # or processing of data fetched by more general queries.
 # For now, these are just conceptual placeholders.
-```


### PR DESCRIPTION
This commit addresses the following:
- Removed a trailing backtick in `client/messages_agent.py` that caused an error when running agent.py.
- Removed trailing backticks in `server/messages_server.py` and `server/sql_dml.py` found during a general syntax review.

These corrections ensure the Python scripts are syntactically valid.