### PR TITLE
feat: Separate machine monitoring and application usage logs

### DIFF
--- a/client/messages_agent.py
+++ b/client/messages_agent.py
@@ -36,7 +36,7 @@ MSG_LOGGING_TO_FILE = "Logging data to: {}"
 MSG_LOG_FILE_DAILY_CHANGE = "New day, logging to: {}"
 MSG_LOG_FILE_WRITING_ERROR = "Error writing to log file '{}': {}"
 MSG_LOG_PATH_ERROR = "Error ensuring log path '{}' exists or writing to file: {}"
-MSG_JSON_SERIALIZATION_ERROR = "Error serializing data to JSON for logging: {}. Payload was: {}"
+MSG_JSON_SERIALIZATION_ERROR = "Error serializing {} to JSON for logging: {}. Payload was: {}"
 
 # --- Data Transmission Messages ---
 MSG_SENDING_DATA_TO_SERVER = "Data successfully sent to {} (Status: {})"
@@ -45,7 +45,7 @@ MSG_SEND_CONNECTION_ERROR = "Connection error sending data to {}: {}"
 MSG_SEND_TIMEOUT_ERROR = "Timeout sending data to {}: {}"
 MSG_SEND_REQUEST_EXCEPTION = "Error sending data to {}: {}"
 MSG_SEND_UNEXPECTED_ERROR = "Unexpected error in send_data_to_server: {}"
-MSG_SEND_SKIPPING_JSON_ERROR = "Skipping data transmission due to JSON serialization error for logging."
+MSG_SEND_SKIPPING_JSON_ERROR = "Skipping transmission of {} due to JSON serialization error during logging."
 
 # --- General Error Messages ---
 MSG_UNEXPECTED_ERROR_MAIN_LOOP = "An unexpected error occurred in the main loop: {}"

--- a/server/sql_ddl.py
+++ b/server/sql_ddl.py
@@ -33,10 +33,21 @@ CREATE TABLE IF NOT EXISTS activity_logs (
     timestamp DATETIME NOT NULL,
     free_disk_space_gb FLOAT,
     cpu_usage_percent FLOAT,
-    gpu_usage_percent FLOAT,
-    active_window_title VARCHAR(512),
+        gpu_usage_percent FLOAT,  # Comma removed from here
     INDEX idx_activity_computer_id_timestamp (computer_id, timestamp), /* Composite index */
     INDEX idx_activity_timestamp (timestamp), /* Separate index on timestamp can also be useful */
+    FOREIGN KEY (computer_id) REFERENCES computers(id) ON DELETE CASCADE
+) ENGINE=InnoDB;
+"""
+
+CREATE_APPLICATION_USAGE_LOGS_TABLE = """
+CREATE TABLE IF NOT EXISTS application_usage_logs (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    computer_id INT NOT NULL,
+    timestamp DATETIME NOT NULL,
+    active_window_title VARCHAR(512),
+    INDEX idx_app_usage_computer_id_timestamp (computer_id, timestamp),
+    INDEX idx_app_usage_timestamp (timestamp),
     FOREIGN KEY (computer_id) REFERENCES computers(id) ON DELETE CASCADE
 ) ENGINE=InnoDB;
 """
@@ -45,5 +56,6 @@ CREATE TABLE IF NOT EXISTS activity_logs (
 ALL_TABLES_DDL = [
     CREATE_COMPUTER_GROUPS_TABLE,
     CREATE_COMPUTERS_TABLE,
-    CREATE_ACTIVITY_LOGS_TABLE
+    CREATE_ACTIVITY_LOGS_TABLE,
+    CREATE_APPLICATION_USAGE_LOGS_TABLE
 ]

--- a/server/sql_dml.py
+++ b/server/sql_dml.py
@@ -5,12 +5,18 @@
 
 # --- Queries for /log_activity endpoint ---
 SELECT_COMPUTER_BY_NETBIOS = "SELECT id FROM computers WHERE netbios_name = %s"
-UPDATE_COMPUTER_LAST_SEEN_IP = "UPDATE computers SET ip_address = %s, last_seen = NOW() WHERE id = %s"
-INSERT_NEW_COMPUTER = "INSERT INTO computers (netbios_name, ip_address, last_seen) VALUES (%s, %s, NOW())"
+UPDATE_COMPUTER_LAST_SEEN_IP = "UPDATE computers SET ip_address = %s, last_seen = %s WHERE id = %s"
+INSERT_NEW_COMPUTER = "INSERT INTO computers (netbios_name, ip_address, last_seen) VALUES (%s, %s, %s)"
 INSERT_ACTIVITY_LOG = """
     INSERT INTO activity_logs
-    (computer_id, timestamp, free_disk_space_gb, cpu_usage_percent, gpu_usage_percent, active_window_title)
-    VALUES (%s, %s, %s, %s, %s, %s)
+    (computer_id, timestamp, free_disk_space_gb, cpu_usage_percent, gpu_usage_percent)
+    VALUES (%s, %s, %s, %s, %s)
+"""
+
+INSERT_APPLICATION_LOG = """
+    INSERT INTO application_usage_logs
+    (computer_id, timestamp, active_window_title)
+    VALUES (%s, %s, %s)
 """
 
 # --- Queries for Group Management API (/api/groups/*) ---


### PR DESCRIPTION
This commit refactors the logging mechanism to distinguish between general machine statistics and application usage data.

Agent (Client):
- Now generates two distinct JSON payloads:
  1. `machine_payload`: Contains system metrics (IP, disk, CPU, GPU) with `log_type: "machine"`.
  2. `application_payload`: Contains active window title with `log_type: "application"`.
- Both payloads include `timestamp` and `netbios_name`.
- Sends each payload type to the server independently.
- Local file logging also reflects this separation.
- CPU/GPU data is now always included if available, alert threshold logic removed from client payload generation.

Server:
- `/log_activity` endpoint now inspects `log_type` from the payload.
- Client-provided `timestamp` is now used for `last_seen` in the `computers` table and for all log entries, instead of `NOW()`.
- DML for `computers` table (`UPDATE_COMPUTER_LAST_SEEN_IP`, `INSERT_NEW_COMPUTER`) updated accordingly.
- New table `application_usage_logs` created to store `computer_id`, `timestamp`, and `active_window_title`.
- `activity_logs` table schema modified to remove `active_window_title`; it now only stores machine-specific metrics.
- DML statements for `activity_logs` and the new `application_usage_logs` updated to match new schemas and logic.
- Server logic routes "machine" logs to `activity_logs` and "application" logs to `application_usage_logs`.
- Application logs for unknown machines are rejected until a machine log creates the computer record.