### PR TITLE
I've made a change to how I report CPU and GPU usage. Now, I'll only …

### DIFF
--- a/client/agent.py
+++ b/client/agent.py
@@ -256,14 +256,27 @@ def main():
             gpu_val = get_gpu_usage()
             active_title = get_active_window_title()
 
+            cpu_alert_threshold = app_config.get('cpu_alert_threshold', 90) # Default 90 if not in config
+            gpu_alert_threshold = app_config.get('gpu_alert_threshold', 90) # Default 90 if not in config
+
+            final_cpu_usage = None
+            if cpu_val is not None:
+                if cpu_val > cpu_alert_threshold:
+                    final_cpu_usage = round(cpu_val, 1)
+
+            final_gpu_usage = None
+            if gpu_val is not None:
+                if gpu_val > gpu_alert_threshold:
+                    final_gpu_usage = round(gpu_val, 1)
+
             machine_payload = {
                 "log_type": "machine",
                 "timestamp": current_time.isoformat(),
                 "netbios_name": netbios_name,
                 "ip_address": ip_address,
-                "free_disk_space_gb": free_space_gb, # free_space_gb is already rounded or None
-                "cpu_usage_percent": round(cpu_val, 1) if cpu_val is not None else None,
-                "gpu_usage_percent": round(gpu_val, 1) if gpu_val is not None else None
+                "free_disk_space_gb": free_space_gb,
+                "cpu_usage_percent": final_cpu_usage,
+                "gpu_usage_percent": final_gpu_usage
             }
 
             application_payload = {


### PR DESCRIPTION
…send you the CPU and GPU usage percentages if they go above certain alert levels we've set.

- If the CPU usage is higher than the `cpu_alert_threshold`, I'll include the `cpu_usage_percent` in the information I send. Otherwise, it will be `null`.
- Similarly, if the GPU usage is above the `gpu_alert_threshold`, I'll include the `gpu_usage_percent`. Otherwise, that will also be `null`.

This is a return to how things were, based on your feedback, instead of me sending this information all the time. The way this information is handled on the server side hasn't changed and will record `null` if I don't provide these details.