### PR TITLE
chore: Add disk_space_alert_threshold_gb to your client config

### DIFF
--- a/client/config.ini
+++ b/client/config.ini
@@ -5,3 +5,4 @@ address = localhost
 cpu_alert_threshold = 90
 gpu_alert_threshold = 90
 log_folder = .
+disk_space_alert_threshold_gb = 20


### PR DESCRIPTION
This ensures that `client/config.ini` contains the `disk_space_alert_threshold_gb` setting under the `[agent_settings]` section, defaulting to 20 if it was not already present.

This supports the recently added feature for threshold-based disk space reporting.