### PR TITLE
feat: Add OS name and version tracking for computers

### DIFF
--- a/client/agent.py
+++ b/client/agent.py
@@ -1,4 +1,5 @@
 import configparser
+import platform
 import time
 import os
 import socket
@@ -267,6 +268,14 @@ def main():
                 if current_free_space_gb_rounded < app_config['disk_space_alert_threshold_gb']:
                     payload_free_disk_space_gb = current_free_space_gb_rounded
 
+            try:
+                os_name = platform.system()
+                os_version = platform.release()
+            except Exception as e:
+                print(f"Error getting OS info: {e}") # Or use a message from messages_agent.py
+                os_name = "N/A"
+                os_version = "N/A"
+
             cpu_val = get_cpu_usage()
             gpu_val = get_gpu_usage()
             active_title = get_active_window_title()
@@ -291,7 +300,9 @@ def main():
                 "ip_address": ip_address,
                 "free_disk_space_gb": payload_free_disk_space_gb, # Use the thresholded and rounded value
                 "cpu_usage_percent": final_cpu_usage,
-                "gpu_usage_percent": final_gpu_usage
+                "gpu_usage_percent": final_gpu_usage,
+                "os_name": os_name,                               # New field
+                "os_version": os_version                          # New field
             }
 
             application_payload = {

--- a/server/server.py
+++ b/server/server.py
@@ -244,12 +244,14 @@ def log_activity():
             if not ip_address or not str(ip_address).strip():
                 return jsonify(status="error", message="Missing or empty required key 'ip_address' for log_type 'machine'"), 400
             ip_address = str(ip_address).strip()
+            os_name = data.get('os_name') # Defaults to None if not present
+            os_version = data.get('os_version') # Defaults to None if not present
 
             if result: # Computer exists
                 computer_id = result[0]
-                cursor.execute(sql_dml.UPDATE_COMPUTER_LAST_SEEN_IP, (ip_address, parsed_timestamp, computer_id))
+                cursor.execute(sql_dml.UPDATE_COMPUTER_LAST_SEEN_IP, (ip_address, parsed_timestamp, os_name, os_version, computer_id))
             else: # New computer
-                cursor.execute(sql_dml.INSERT_NEW_COMPUTER, (netbios_name, ip_address, parsed_timestamp))
+                cursor.execute(sql_dml.INSERT_NEW_COMPUTER, (netbios_name, ip_address, parsed_timestamp, os_name, os_version))
                 computer_id = cursor.lastrowid
 
             if not computer_id:

--- a/server/sql_ddl.py
+++ b/server/sql_ddl.py
@@ -19,6 +19,8 @@ CREATE TABLE IF NOT EXISTS computers (
     ip_address VARCHAR(45),
     last_seen DATETIME,
     group_id INT,
+        os_name VARCHAR(100) NULL,    -- New column
+        os_version VARCHAR(100) NULL, -- New column
     INDEX idx_computer_netbios_name (netbios_name),
     INDEX idx_computer_last_seen (last_seen),
     INDEX idx_computer_group_id (group_id), /* Added index for FK */

--- a/server/sql_dml.py
+++ b/server/sql_dml.py
@@ -5,8 +5,8 @@
 
 # --- Queries for /log_activity endpoint ---
 SELECT_COMPUTER_BY_NETBIOS = "SELECT id FROM computers WHERE netbios_name = %s"
-UPDATE_COMPUTER_LAST_SEEN_IP = "UPDATE computers SET ip_address = %s, last_seen = %s WHERE id = %s"
-INSERT_NEW_COMPUTER = "INSERT INTO computers (netbios_name, ip_address, last_seen) VALUES (%s, %s, %s)"
+UPDATE_COMPUTER_LAST_SEEN_IP = "UPDATE computers SET ip_address = %s, last_seen = %s, os_name = %s, os_version = %s WHERE id = %s"
+INSERT_NEW_COMPUTER = "INSERT INTO computers (netbios_name, ip_address, last_seen, os_name, os_version) VALUES (%s, %s, %s, %s, %s)"
 INSERT_ACTIVITY_LOG = """
     INSERT INTO activity_logs
     (computer_id, timestamp, free_disk_space_gb, cpu_usage_percent, gpu_usage_percent)


### PR DESCRIPTION
This commit enhances the system to collect, transmit, and store Operating System (OS) information for each monitored computer.

Agent (client/agent.py):
- Imports the `platform` module.
- Collects OS name using `platform.system()` and OS version using `platform.release()`.
- Adds `os_name` and `os_version` fields to the `machine_payload` sent to the server.

Server:
- `server/sql_ddl.py`:
  - The `computers` table schema in `CREATE_COMPUTERS_TABLE` is updated to include two new nullable columns: `os_name VARCHAR(100)` and `os_version VARCHAR(100)`.
- `server/sql_dml.py`:
  - `INSERT_NEW_COMPUTER` DML statement now includes `os_name` and `os_version` fields and corresponding value placeholders.
  - `UPDATE_COMPUTER_LAST_SEEN_IP` DML statement is updated to also set `os_name` and `os_version`.
- `server/server.py`:
  - The `log_activity` function, when processing `log_type == "machine"`, now extracts `os_name` and `os_version` from the payload.
  - These extracted OS details are passed to the updated DML operations for inserting new computer records or updating existing ones.

This allows for better inventory and identification of machines by their OS within the monitoring system.