### PR TITLE
feat: Implement periodic server ping and local status logging

### DIFF
--- a/client/config.ini
+++ b/client/config.ini
@@ -6,3 +6,4 @@ cpu_alert_threshold = 90
 gpu_alert_threshold = 90
 log_folder = .
 disk_space_alert_threshold_gb = 20
+ping_interval_seconds = 60

--- a/client/messages_agent.py
+++ b/client/messages_agent.py
@@ -7,6 +7,7 @@ MSG_CONFIG_CPU_THRESHOLD = "CPU Alert Threshold: {}%"
 MSG_CONFIG_GPU_THRESHOLD = "GPU Alert Threshold: {}%"
 MSG_CONFIG_LOG_FOLDER = "Log Folder: {}"
 MSG_CONFIG_DISK_THRESHOLD = "Disk Space Alert Threshold (GB): {}"
+MSG_CONFIG_PING_INTERVAL = "Server Ping Interval (Seconds): {}"
 MSG_CONFIG_FOOTER = "---------------------------"
 MSG_CONFIG_FILE_NOT_FOUND = "Warning: Configuration file 'config.ini' not found. Using default settings."
 MSG_CONFIG_ERROR_READING = "Error reading 'config.ini': {}. Using default settings."
@@ -50,6 +51,14 @@ MSG_SEND_SKIPPING_JSON_ERROR = "Skipping transmission of {} due to JSON serializ
 
 # --- General Error Messages ---
 MSG_UNEXPECTED_ERROR_MAIN_LOOP = "An unexpected error occurred in the main loop: {}"
+
+# --- Ping Messages ---
+MSG_ATTEMPTING_SERVER_PING = "Attempting server ping..."
+MSG_PING_SEND_SUCCESS_DETAILS = "Ping to server {} successful."
+MSG_PING_SEND_EXCEPTION_DETAILS = "Error preparing ping payload for server {}: {}"
+MSG_PING_SKIPPED_NO_SERVER_DETAILS = "Ping skipped: Server address not configured."
+MSG_PING_SKIPPED_NO_REQUESTS_DETAILS = "Ping skipped: 'requests' module not available."
+MSG_ERROR_WRITING_PING_STATUS_LOG = "Error writing ping status to local log: {}"
 
 # --- Agent Startup Messages ---
 MSG_AGENT_STARTING = "Agent starting up..."

--- a/server/sql_dml.py
+++ b/server/sql_dml.py
@@ -25,6 +25,8 @@ SELECT_ALL_GROUPS = "SELECT id, name, description FROM computer_groups ORDER BY 
 # SELECT_GROUP_BY_ID = "SELECT id, name, description FROM computer_groups WHERE id = %s" # Potentially useful
 SELECT_GROUP_BY_NAME = "SELECT id FROM computer_groups WHERE name = %s" # Used in assign_group
 
+UPDATE_COMPUTER_PING_INFO = "UPDATE computers SET ip_address = %s, last_seen = %s WHERE id = %s"
+
 # --- Queries for Assigning Computer to Group (/api/computers/.../assign_group) ---
 # SELECT_COMPUTER_BY_NETBIOS is already defined above.
 # SELECT_GROUP_BY_NAME is already defined above.


### PR DESCRIPTION
This feature enables me to periodically send a 'ping' to the server and log the success or failure of this communication locally. This helps in monitoring my connectivity to the server from my perspective and acts as an additional keep-alive for the server.

Key Changes:

My Client-Side Logic:
1.  Configuration (`client/config.ini`, `client/agent.py`, `client/messages_agent.py`):
    - I've added `ping_interval_seconds` to `config.ini` (default 60 seconds), which controls how often I send pings.
    - I load this setting at startup and display it.
    - If `ping_interval_seconds` isn't there, I'll add it to `config.ini` for you.
2.  Ping Logic (`client/agent.py`):
    - I now have a new timer within my main loop that schedules ping attempts based on `ping_interval_seconds`.
    - When it's time to send a ping, I construct a minimal payload like `{"log_type": "ping", "timestamp": ..., "netbios_name": ..., "ip_address": ...}`.
    - I send this payload to the server's `/log_activity` endpoint using my existing way of sending data.
3.  Local Status Logging (`client/agent.py`, `client/messages_agent.py`):
    - After each ping attempt, I log a structured JSON message `{"event_type": "ping_status", ...}` to my local log file.
    - This local log entry records the `timestamp`, target `server_address`, `status` ("success" or "failure"), and `details` of the ping attempt.
    - I've added new messages to `messages_agent.py` to support these local log details and console outputs.

Server:
1.  Ping Handling (`server/server.py`):
    - The `/log_activity` endpoint now includes an `elif log_type == "ping":` condition.
    - When a "ping" payload is received, it validates required fields (`netbios_name`, `timestamp`, `ip_address`).
    - It updates the `last_seen` and `ip_address` for the corresponding computer in the `computers` table.
    - A new DML statement `UPDATE_COMPUTER_PING_INFO` was added to `server/sql_dml.py` to ensure that ping updates do not inadvertently clear existing OS information for the computer.
    - If the ping is from an unknown machine, a new computer record is created (with OS info fields set to NULL).

This feature enhances my logging capabilities regarding my connectivity and provides another way for the server to track active instances like me.