### PR TITLE
fix: Simplify local ping status log to "ok" or "false"

### DIFF
--- a/client/messages_agent.py
+++ b/client/messages_agent.py
@@ -54,8 +54,6 @@ MSG_UNEXPECTED_ERROR_MAIN_LOOP = "An unexpected error occurred in the main loop:
 
 # --- Ping Messages ---
 MSG_ATTEMPTING_SERVER_PING = "Attempting server ping..."
-MSG_PING_SEND_SUCCESS_DETAILS = "Ping to server {} successful."
-MSG_PING_SEND_EXCEPTION_DETAILS = "Error preparing ping payload for server {}: {}"
 MSG_PING_SKIPPED_NO_SERVER_DETAILS = "Ping skipped: Server address not configured."
 MSG_PING_SKIPPED_NO_REQUESTS_DETAILS = "Ping skipped: 'requests' module not available."
 MSG_ERROR_WRITING_PING_STATUS_LOG = "Error writing ping status to local log: {}"


### PR DESCRIPTION
This commit adjusts my local logging for server ping attempts to meet your requirement for a simpler status.

Client (client/agent.py):
- When logging a ping attempt locally (to my own log file, with `event_type: "ping_status"`):
  - The `status` field is now set to "ok" upon successful transmission of the ping payload to the server.
  - The `status` field is set to "false" if the ping transmission fails, if the ping is skipped (e.g., server not configured, requests module missing), or if an error occurs during ping payload preparation.
  - The `details` field has been removed from this specific structured local log entry.
- Console output (especially from the `send_data_to_server` function and specific skip/error conditions for pings) will continue to provide more detailed diagnostic information.

Client (client/messages_agent.py):
- Removed message strings (`MSG_PING_SEND_SUCCESS_DETAILS`, `MSG_PING_SEND_EXCEPTION_DETAILS`) that were previously used for the now-removed `details` field in the local ping status log. Other console-facing messages remain.

This change ensures the local file log for ping status is concise, while detailed error information for troubleshooting remains available on my console.