### PR TITLE
Add server/db_config.ini for database configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,3 +321,47 @@ This project consists of a Python Flask backend and a React frontend.
 
 Once both the backend server is running and the frontend has been built (and Flask is serving it):
 - Open your browser and navigate to `http://localhost:5000` (or the port your Flask server is running on).
+
+
+## Server Database Configuration
+
+The server component requires a connection to a MariaDB database. Configuration for this connection is managed through the `server/db_config.ini` file.
+
+### `server/db_config.ini`
+
+This file must contain the following details under a `[database]` section:
+
+-   `host`: The hostname or IP address of your MariaDB server.
+-   `user`: The username for the database connection.
+-   `password`: The password for the specified user.
+-   `name`: The name of the database to be used (e.g., `agent_data_db`).
+
+A template `server/db_config.ini` is provided with placeholder values. You **must** replace these placeholders with your actual database credentials.
+
+**Example `server/db_config.ini`:**
+```ini
+[database]
+host = 127.0.0.1
+user = my_db_user
+password = my_secret_password
+name = agent_data_db
+```
+
+### Automatic Configuration using `setup_database.py`
+
+Alternatively, you can run the `server/setup_database.py` script:
+
+```bash
+python server/setup_database.py
+```
+
+This script will interactively prompt you for the database details, attempt to connect to the database, create the necessary tables (if they don't exist), and then automatically generate the `server/db_config.ini` file with the provided information.
+
+### Security Note
+
+Ensure that the `server/db_config.ini` file is secured appropriately. It contains sensitive database credentials. It is highly recommended to add this file to your `.gitignore` file if it's not already included, to prevent accidental commitment of credentials to your repository.
+
+```
+# Example .gitignore entry
+server/db_config.ini
+```

--- a/server/db_config.ini
+++ b/server/db_config.ini
@@ -1,0 +1,17 @@
+; Database configuration file for the server application
+;
+; Please replace the placeholder values below with your actual
+; MariaDB database connection details.
+;
+; Alternatively, you can run the server/setup_database.py script
+; which will guide you through the setup process and generate this
+; file automatically.
+
+[database]
+host = YOUR_DATABASE_HOST
+user = YOUR_DATABASE_USER
+password = YOUR_DATABASE_PASSWORD
+name = agent_data_db ; Or your specific database name
+
+; Ensure this file is secured and consider adding it to .gitignore
+; if it's not already ignored, to prevent committing credentials.


### PR DESCRIPTION
This commit introduces the `server/db_config.ini` file to allow you to specify your MariaDB database connection details (host, user, password, name).

The `server/server.py` script was already capable of reading this INI file, so no modifications were needed there. The server will use the credentials from `db_config.ini` to connect to the database.

The `README.md` has been updated to:
- Explain the structure and purpose of `server/db_config.ini`.
- Instruct you to replace placeholder values with your actual credentials.
- Highlight the existing `server/setup_database.py` script, which can be used to interactively set up the database and automatically generate `db_config.ini`.
- Include a security note regarding the handling of `db_config.ini` and recommending its inclusion in `.gitignore`.

This change fulfills the requirement to add an INI file for server database settings and ensures you are informed on how to configure it.