### PR TITLE
fix: Correct SyntaxError in server.py log_activity function

### DIFF
--- a/server/server.py
+++ b/server/server.py
@@ -376,37 +376,39 @@ def log_activity():
             ))
             print(f"Application log for computer_id {computer_id} (Active Window: '{active_window_title}') inserted into application_usage_logs.")
 
-    elif log_type == "ping":
-        ip_address = data.get('ip_address')
-        if not ip_address or not str(ip_address).strip():
-            return jsonify(status="error", message="Missing or empty required key 'ip_address' for log_type 'ping'"), 400
-        ip_address = str(ip_address).strip()
+        elif log_type == "ping":
+            ip_address = data.get('ip_address')
+            if not ip_address or not str(ip_address).strip():
+                return jsonify(status="error", message="Missing or empty required key 'ip_address' for log_type 'ping'"), 400
+            ip_address = str(ip_address).strip()
 
-        # 'netbios_name' and 'parsed_timestamp' are already validated and available.
-        # 'result' from SELECT_COMPUTER_BY_NETBIOS is also available.
+            # 'netbios_name' and 'parsed_timestamp' are already validated and available.
+            # 'result' from SELECT_COMPUTER_BY_NETBIOS is also available.
 
-        computer_id = None
-        if not result: # Computer not found, create it
-            # INSERT_NEW_COMPUTER expects: netbios_name, ip_address, parsed_timestamp, os_name, os_version
-            cursor.execute(sql_dml.INSERT_NEW_COMPUTER, (netbios_name, ip_address, parsed_timestamp, None, None))
-            computer_id = cursor.lastrowid
-            if not computer_id:
-                if conn: conn.rollback()
-                return jsonify(status="error", message="Failed to create new computer record from ping"), 500
-            print(f"New computer '{netbios_name}' created from ping.")
-        else: # Computer exists
-            computer_id = result[0]
-            cursor.execute(sql_dml.UPDATE_COMPUTER_PING_INFO, (ip_address, parsed_timestamp, computer_id))
+            computer_id = None
+            if not result: # Computer not found, create it
+                # INSERT_NEW_COMPUTER expects: netbios_name, ip_address, parsed_timestamp, os_name, os_version
+                cursor.execute(sql_dml.INSERT_NEW_COMPUTER, (netbios_name, ip_address, parsed_timestamp, None, None))
+                computer_id = cursor.lastrowid
+                if not computer_id:
+                    # No commit here, let the error handling do its job (rollback)
+                    return jsonify(status="error", message="Failed to create new computer record from ping"), 500
+                print(f"New computer '{netbios_name}' created from ping.")
+            else: # Computer exists
+                computer_id = result[0]
+                cursor.execute(sql_dml.UPDATE_COMPUTER_PING_INFO, (ip_address, parsed_timestamp, computer_id))
 
-        print(f"Ping from computer_id {computer_id} ('{netbios_name}') acknowledged and computer record updated.")
-        # Let successful processing fall through to the main commit and success JSON response
+            print(f"Ping from computer_id {computer_id} ('{netbios_name}') acknowledged and computer record updated.")
+            # Successful processing of "ping" falls through to commit and success response.
 
-        else:
-            if conn: conn.rollback()
+        else: # Unknown log_type
+            # No commit here, as it's an error condition.
             return jsonify(status="error", message=f"Unknown log_type: {log_type}"), 400
 
+        # conn.commit() and success jsonify are now correctly placed inside the try block,
+        # and will only be reached if no 'return' was hit in the if/elif/else chain above.
         conn.commit()
-        return jsonify(status="success", message=f"Log type '{log_type}' acknowledged for '{netbios_name}'. Computer record updated/verified. Specific data insertion follows in next steps."), 200
+        return jsonify(status="success", message=f"Log type '{log_type}' acknowledged for '{netbios_name}'. Computer record updated/verified."), 200
 
     except mariadb.Error as e:
         if conn:


### PR DESCRIPTION
This commit resolves a SyntaxError in the `log_activity` function of `server/server.py`. The error occurred because the `if/elif/else` block for handling different `log_type` values (machine, application, ping, unknown) was incorrectly indented relative to the main `try...except` block.

The `elif log_type == "ping":` and the subsequent `else:` clause were outside the `try` block but before the `except` clauses, leading to the `SyntaxError: expected 'except' or 'finally' block`.

The fix involves:
- Correctly indenting the entire `if/elif/else` chain for `log_type` to be within the `try` block.
- Ensuring that `conn.commit()` and the final success `return jsonify(...)` are also within the `try` block, following the conditional logic for valid log types.